### PR TITLE
Removed useless initialisation.

### DIFF
--- a/snarkWrapper/contracts/MerkelTree.sol
+++ b/snarkWrapper/contracts/MerkelTree.sol
@@ -13,9 +13,6 @@ contract MerkelTree {
     bytes public vk;
 
     function MerkelTree() {
-        for (uint i = 0; i < 16; i++)
-            MT.leaves[i] = 0x0;
-
     }
 
 


### PR DESCRIPTION
MT leaves are set per default to `0x0`